### PR TITLE
Add taint configuration to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Kubernetes Master
 =========
-Master: [![Build Status](https://travis-ci.org/digital-realms/ansible_role_kubernetes_master.svg?branch=master)](https://travis-ci.org/digital-realms/ansible_role_kubernetes_master)
+Master:
+
+[![Build Status](https://travis-ci.org/digital-realms/ansible_role_kubernetes_master.svg?branch=master)](https://travis-ci.org/digital-realms/ansible_role_kubernetes_master)
 
 This role installs a Kubernetes Master node (standalone) using the new `kubeadm` utility that Kubernetes provides.
 
@@ -20,19 +22,24 @@ The master node has the following Requirements:
 3. Full network connectivity with any other box that will be acting as the minnion(s) of this master.
 
 **NOTE:** Last but not least, please do remember to run this role with `become: yes` to grant privileged access during the installation process.
+
 Role Variables
 --------------
 
 The master has the following variables which will are available to be consumed:
 
-1. `k8s_network_selection:` - this variable has a default value to use `weave`, however, may be overwritten should you wish to use any other networking module. Currently its the **only** module supported. as mentioned above, if you need others, feel free to open an issue and contribute if you're feeling kind and generous :)
+1. `k8s_network_selection:` - This variable has a default value to use `weave`, however, may be overwritten should you wish to use any other networking module. Currently its the **only** module supported. as mentioned above, if you need others, feel free to open an issue and contribute if you're feeling kind and generous :)
 
-2. `k8s_init_xtrargs:` - this allows us to pass in any extra arguments that you might want to pass to the `init` phase of the installation. this is particularly useful should you wish to pass parameters such as:
+2. `k8s_init_xtrargs:` - This allows us to pass in any extra arguments that you might want to pass to the `init` phase of the installation. this is particularly useful should you wish to pass parameters such as:
   * `--api-advertise-addresses=<ip-address>`
   * `--pod-network-cidr=10.244.0.0/16`
   * `--api-external-dns-names=kubernetes.example.com,kube.example.com`.
 
   It's default is an empty string, which means that it will be bypassed.
+
+3. `k8s_taint_mode` - By default, your cluster will not schedule pods on the master for security reasons. If you want to be able to schedule pods on the master, for example if you want a single-machine Kubernetes cluster for development set this variable to `true`.
+                      You can find more information about it [here](http://kubernetes.io/docs/getting-started-guides/kubeadm/) under the `Initializing your master` section
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@
   k8s_weave_path: '/opt/cni/bin/weave-net'
   k8s_network_selection: 'weave'
   k8s_init_xtrargs: ''
+  k8s_taint_mode: false

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,0 +1,4 @@
+---
+  - name: ':: configuration :: Configure node to be tainted'
+    command: 'kubectl taint nodes --all dedicated-'
+    when: k8s_taint_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# tasks file for ansible_role_kubernetes_master
   - name: ':: check :: Checking if Kubernetes master has been initialized'
     stat:
       path:  "{{ k8s_token_path }}"
@@ -9,5 +8,6 @@
   - include: RedHat/main.yml
     when: ansible_os_family == "RedHat"
 
-#include debian family here
   - include: network.yml
+
+  - include: configuration.yml


### PR DESCRIPTION
Closes #3 

# How to test
Try schedule a pod with only the master for example
```
$ kubectl run my-nginx --image=nginx --replicas=2 --port=80
```
you will see that the pod will never get scheduled.

If you re-run the playbook with the `k8s_taint_mode` set to `true` the pods will get scheduled.

# Things that might need improvement
* Naming to the variable itself. 