### PR TITLE
Issue #4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2017 Digital Realms
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Should you wish to be a little bit more adventurous and would like to pass in fu
 License
 -------
 
-MIT
+[MIT](LICENSE)
 
 Author Information
 ------------------

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The master has the following variables which will are available to be consumed:
 3. `k8s_taint_mode` - By default, your cluster will not schedule pods on the master for security reasons. If you want to be able to schedule pods on the master, for example if you want a single-machine Kubernetes cluster for development set this variable to `true`.
                       You can find more information about it [here](http://kubernetes.io/docs/getting-started-guides/kubeadm/) under the `Initializing your master` section
 
+4. `install_docker` - By default this role will install docker for you, if you would like to mange docker yourself, just set this variable to `false` and the role will skip the installation.
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
-# defaults file for ansible_role_kubernetes_master
+  # Defaults file for ansible_role_kubernetes_master
   k8s_token_path: '/etc/kubernetes/cluster_token'
   k8s_weave_path: '/opt/cni/bin/weave-net'
   k8s_network_selection: 'weave'
   k8s_init_xtrargs: ''
   k8s_taint_mode: false
+  install_docker: true

--- a/tasks/RedHat/packages.yml
+++ b/tasks/RedHat/packages.yml
@@ -11,12 +11,17 @@
       gpgcheck: true
       state: present
 
+  - name: ':: yum :: Install Docker'
+    yum:
+      name: 'docker'
+      state: installed
+    when: install_docker
+
   - name: ':: yum :: Installing Kubernetes packages'
     yum:
       name: "{{ item }}"
       state: installed
     with_items:
-      - docker
       - kubelet
       - kubeadm
       - kubectl


### PR DESCRIPTION
Closes issue #4. 

Added a new variable `install_docker` that is set by default to true. If the user wants to manage docker outside of this role he can simply set this to false.

*NOTE* We are still making sure/starting the service since it is needed to run kubernetes. 